### PR TITLE
Support manual tool change with GRBL post-processor

### DIFF
--- a/PostProcessAll.py
+++ b/PostProcessAll.py
@@ -898,6 +898,7 @@ def PostProcessSetup(fname, setup, setupFolder, docSettings):
             r"(M(?P<M>[0-9]+) *)?" # M-code
             r"(G(?P<G>[0-9]+) *)?" # G-code
             r"(T(?P<T>[0-9]+))?" # Tool
+            r"(\([A-Z ]+ T(?P<T2>[0-9]+)\))?" # Manual tool change comment
             r".+)",              # to end of line
             re.IGNORECASE | re.DOTALL)
         toolChange = docSettings["toolChange"]
@@ -1013,6 +1014,10 @@ def PostProcessSetup(fname, setup, setupFolder, docSettings):
             #
             # Txx ...   (optionally preceded by line number Nxx)
             #
+            # Or a localized message like:
+            #
+            # (MANUAL TOOL CHANGE TO Txx)
+            #
             # We copy all the body, looking for the tail. The start
             # of the tail is denoted by any of a list of G-codes
             # entered by the user. The defaults are:
@@ -1062,7 +1067,7 @@ def PostProcessSetup(fname, setup, setupFolder, docSettings):
                 fNum = match["N"] != None
                 if (fBody):
                     break
-                toolCur = match["T"]
+                toolCur = match["T"] or match["T2"]
                 if (toolCur != None):
                     toolCur = int(toolCur)
                     if not fFirst:


### PR DESCRIPTION
This change adds support to the gcode parser for manual tool changes outputted by the GRBL post-processor. This post processor emits a comment and pause instead of the `Txx` command we expect, like:

```gcode
(MANUAL TOOL CHANGE TO Txx)
M0
```

Alternatively, we could add a note to the following error saying a user needs to set up their tool library to disable manual tool change and have unique tool numbers.

https://github.com/TimPaterson/Fusion360-Batch-Post/blob/b8d352016ae4241553a36d80cfeb22c2ade77f95/PostProcessAll.py#L1093 

Bug: #77