### PR TITLE
Combine postprocessing for sequential operations with the same tool

### DIFF
--- a/PostProcessAll.py
+++ b/PostProcessAll.py
@@ -1032,13 +1032,15 @@ def PostProcessSetup(fname, setup, setupFolder, docSettings, program):
             if op.isSuppressed:
                 continue
 
-            # Look ahead for operations without a toolpath. This can happen
-            # with a manual operation. Group it with current operation.
+            # Look ahead for operations without a toolpath, or operations with the same tool.
+            # This can happen with a manual operation. Group it with current operation.
             # Or if first, group it with subsequent ones.
             opHasTool = None
+            currentTool = None
             hasTool = op.hasToolpath
             if hasTool:
                 opHasTool = op
+                currentTool = json.loads(op.tool.toJson())["guid"]
             opList = [op]
             while i < ops.count:
                 op = ops[i]
@@ -1046,11 +1048,15 @@ def PostProcessSetup(fname, setup, setupFolder, docSettings, program):
                     i += 1
                     continue
                 if op.hasToolpath:
-                    if not hasTool:
-                        opList.append(op)
-                        opHasTool = op
-                        i += 1
-                    break
+                    nextTool = json.loads(op.tool.toJson())["guid"]
+                    if nextTool != currentTool:
+                        currentTool = nextTool
+
+                        if not hasTool:
+                            opList.append(op)
+                            opHasTool = op
+                            i += 1
+                        break
                 opList.append(op)
                 i += 1
 


### PR DESCRIPTION
PR for https://github.com/TimPaterson/Fusion360-Batch-Post/issues/84

Combines sequential operations before postprocessing if they share the same tool ID as the previous operation.

This allows postprocessing of multiple operations at once in fusion, so that the post processor can be aware of state (like current spindle RPM), skipping unnecessary speed changes or pauses.

This has two side effects that I can see, comparing the before and after gcode:

1. The output header that lists each operation and its Z-Min value now lists one line for the tool instead. This is expected, but maybe it's helpful to see the z-min of individual operations anyway?
2. I'm seeing some subtle differences in a couple of places for how z travel is converted to G0/G00/G1 but I don't fully understand it. Looking at the raw output from fusion without PPA, I think the current output is what I'd expect, but maybe you have better insight there.